### PR TITLE
Computing real digits and phi number system

### DIFF
--- a/Changes
+++ b/Changes
@@ -2,5 +2,8 @@ Revision history for Math::Sequences
 
 {{$NEXT}}
 
+0.1.1  2025-01-04
+    - Implemented the subs real-digits and phi-number-system.
+
 0.1  2024-12-12T13:04:10+01:00
     - Initial version as Raku Community module

--- a/Changes
+++ b/Changes
@@ -4,6 +4,7 @@ Revision history for Math::Sequences
 
 0.1.1  2025-01-04
     - Implemented the subs real-digits and phi-number-system.
+    - Added golden ratio constants both \phi and \ϕ.
 
 0.1  2024-12-12T13:04:10+01:00
     - Initial version as Raku Community module

--- a/META6.json
+++ b/META6.json
@@ -1,32 +1,25 @@
 {
-  "auth": "zef:raku-community-modules",
-  "authors": [
-    "Aaron Sherman",
-    "JJ Merelo"
-  ],
-  "build-depends": [
-  ],
-  "depends": [
-    "Lingua::EN::Numbers"
-  ],
-  "description": "Various mathematical sequences of moderate use",
-  "license": "Artistic-2.0",
-  "name": "Math::Sequences",
-  "perl": "6.c",
-  "provides": {
-    "Math::Sequences": "lib/Math/Sequences.rakumod",
-    "Math::Sequences::Integer": "lib/Math/Sequences/Integer.rakumod",
-    "Math::Sequences::Numberphile": "lib/Math/Sequences/Numberphile.rakumod",
-    "Math::Sequences::Real": "lib/Math/Sequences/Real.rakumod",
-    "Math::Util::Roman": "lib/Math/Util/Roman.rakumod",
-    "Math::Util::SpellNumbers": "lib/Math/Util/SpellNumbers.rakumod"
-  },
-  "resources": [
-  ],
-  "source-url": "https://github.com/raku-community-modules/Math-Sequences.git",
-  "tags": [
-  ],
-  "test-depends": [
-  ],
-  "version": "0.1"
+    "name": "Math::Sequences",
+    "description": "Various mathematical sequences of moderate use.",
+    "version": "0.1.1",
+    "authors": [
+        "Aaron Sherman",
+        "JJ Merelo",
+        "Anton Antonov"
+    ],
+    "auth": "zef:raku-community-modules",
+    "depends": [
+        "Lingua::EN::Numbers"
+    ],
+    "build-depends": [],
+    "provides": {
+        "Math::Sequences": "lib/Math/Sequences.rakumod",
+        "Math::Sequences::Integer": "lib/Math/Sequences/Integer.rakumod",
+        "Math::Sequences::Numberphile": "lib/Math/Sequences/Numberphile.rakumod",
+        "Math::Sequences::Real": "lib/Math/Sequences/Real.rakumod",
+        "Math::Util::Roman": "lib/Math/Util/Roman.rakumod",
+        "Math::Util::SpellNumbers": "lib/Math/Util/SpellNumbers.rakumod"
+    },
+    "license": "Artistic-2.0",
+    "source-url": "https://github.com/raku-community-modules/Math-Sequences.git"
 }

--- a/examples/phi-number-system.raku
+++ b/examples/phi-number-system.raku
@@ -1,0 +1,21 @@
+#!/usr/bin/env raku
+use v6.d;
+
+use Math::Sequences::Numberphile;
+
+# 32
+my $n = 32;
+#my @res = phi-number-system($n, tol => 10e-12, :40length);
+my @res = phi-number-system($n);
+
+say (:$n, :@res);
+
+say @res.map({ ϕ ** $_ }).sum.round(10e-11);
+
+## 2025
+$n = 2025;
+@res = phi-number-system($n);
+
+say (:$n, :@res);
+
+say @res.map({ ϕ ** $_ }).sum.round(10e-11);

--- a/lib/Math/Sequences/Numberphile.rakumod
+++ b/lib/Math/Sequences/Numberphile.rakumod
@@ -301,16 +301,21 @@ our @A316667 is export = spiral-knight;
 # Real digits
 #==========================================================
 #| Real digits
-proto sub real-digits(Numeric:D $x, Numeric:D $b = 10, $n = Whatever, *%args) is export {*}
+#| C<$x> -- number to convert.
+#| C<:$base> -- conversion base.
+#| C<:$n> -- digit exponent to start with.
+#| C<:$tol> -- tolerance to stop the conversion with.
+#| C<:$length> -- max number of digits.
+proto sub real-digits(Numeric:D $x, *@args, *%args) is export {*}
 
-multi sub real-digits(Int:D $x, *@args, *%args) {
-	return real-digits($x.FatRat, |@args, |%args);
+multi sub real-digits($x, Numeric:D $b = 10, $n = Whatever, *%args) {
+	return real-digits($x ~~ Int:D ?? $x.FatRat !! $x, :$b, :$n, |%args);
 }
 
 multi sub real-digits(Numeric:D $x is copy,
-					  Numeric:D $b = 10,
-					  $n is copy = Whatever,
-					  Numeric:D :$tol = 10e-14,
+					  Numeric:D :base(:$b) = 10,
+					  :start(:first-digit-exponent(:$n)) is copy = Whatever,
+					  Numeric:D :tolerance(:$tol) = 10e-14,
 					  :l(:len(:$length)) is copy = Inf) {
 	if $x == 0 { return 0, 0}
 	$x = abs($x);
@@ -373,8 +378,11 @@ our constant \phi is export = $fibonacci401 / $fibonacci400;
 our constant \ϕ is export = $fibonacci401 / $fibonacci400;
 #our constant \ϕ is export = (1.FatRat + $sqrt5) / 2.FatRat;
 
-#|
-sub phi-number-system(Int:D $n, Numeric:D :$tol = 10e-16, :$length is copy = Whatever) is export {
+#| Phi number system.
+#| C<$n> -- an integer number to convert.
+#| C<:$tol> -- tolerance to stop the conversion with.
+#| C<:$length> -- max number of digits.
+sub phi-number-system(Int:D $n, Numeric:D :tolerance(:$tol) = 10e-16, :l(:len(:$length)) is copy = Whatever) is export {
 	if $length.isa(Whatever) { $length = 2 * ($sqrt5 * abs($n)).log(ϕ).floor + 1; }
 	my ($digits, $exp) = real-digits($n.FatRat, ϕ, :$tol, :$length);
 	return $exp <<->> ($digits.grep(* == 1, :k) >>+>> 1);

--- a/lib/Math/Sequences/Numberphile.rakumod
+++ b/lib/Math/Sequences/Numberphile.rakumod
@@ -297,4 +297,47 @@ sub spiral-knight() {
 # and moving to the lowest available unvisited square at each step.
 our @A316667 is export = spiral-knight;
 
-# vim: expandtab shiftwidth=4
+#==========================================================
+# Real digits
+#==========================================================
+#| Real digits
+proto sub real-digits($x, $b, *%args) is export {*}
+
+multi sub real-digits($x,
+					  $b = 10,
+					  $n is copy = Whatever,
+					  Numeric:D :$tol = 10e-14,
+					  :len(:$length) is copy = Inf) {
+	my $abs-x = abs($x);
+	my @digits;
+	my $current = $abs-x;
+
+	if $length.isa(Whatever) { $length = Inf }
+
+	if $n.isa(Whatever) { $n = $x.log($b).floor}
+	if $n.isa(Whatever) { $n = $x.log($b).floor}
+	my $exp = $n;
+
+	while $current > $tol && @digits.elems < $length {
+		my $digit = floor($current / ($b ** $exp));
+		@digits .= push($digit);
+		$current -= $digit * ($b ** $exp);
+		$exp--;
+	}
+
+	return @digits, $n + 1;
+}
+
+#==========================================================
+# Phi number system
+#==========================================================
+# Using N[Sqrt[5].100] in Wolfram Language
+our constant $sqrt5 = 2.236067977499789696409173668731276235440618359611525724270897245410520925637804899414414408378782275.FatRat;
+
+our constant \ϕ is export = (1.FatRat + $sqrt5) / 2.FatRat ;
+
+sub phi-number-system(Int:D $n, :$tol = 10e-16, :$length is copy = Whatever) is export {
+	if $length.isa(Whatever) { $length = 2 * (sqrt(5) * abs($n)).log(ϕ).floor + 3; }
+	my ($digits, $exp) = real-digits($n, ϕ, :$tol, :$length);
+	$exp <<->> ($digits.grep(* == 1, :k) >>+>> 1)
+}

--- a/lib/Math/Sequences/Numberphile.rakumod
+++ b/lib/Math/Sequences/Numberphile.rakumod
@@ -303,6 +303,10 @@ our @A316667 is export = spiral-knight;
 #| Real digits
 proto sub real-digits(Numeric:D $x, Numeric:D $b, *%args) is export {*}
 
+multi sub real-digits(Int:D $x, *@args, *%args) {
+	return real-digits($x.FatRat, |@args, |%args);
+}
+
 multi sub real-digits(Numeric:D $x is copy,
 					  Numeric:D $b = 10,
 					  $n is copy = Whatever,
@@ -314,15 +318,38 @@ multi sub real-digits(Numeric:D $x is copy,
 	my $current = $x;
 
 	if $length.isa(Whatever) { $length = Inf }
+	die 'The argument $length is expected to be a positive integer or Whatever.'
+	unless $length ~~ Int:D && $length > 0;
 
 	if $n.isa(Whatever) { $n = $x.log($b).floor}
-	my $exp = $n;
+	die 'The third argument is expected to be a number or Whatever.' unless $n ~~ Numeric:D;
 
-	while $current / $x > $tol && @digits.elems < $length {
-		my $digit = floor($current / ($b ** $exp));
-		@digits .= push($digit);
-		$current -= $digit * ($b ** $exp);
-		$exp--;
+	if $x ~~ FatRat:D {
+		my $exp = $n.FatRat;
+		my $bf = $b.FatRat;
+
+		my $bfe = [*] ($bf xx $exp);
+		while $current / $x > $tol && @digits.elems < $length {
+			#note (:$exp, power => $bf ** $exp, :$bfe);
+			my $digit = floor($current / $bfe);
+			@digits .= push($digit);
+			$current -= $digit.FatRat * $bfe;
+			#note (:$current);
+			$exp--;
+			$bfe = $bfe / $bf;
+		}
+	} else {
+		my $exp = $n;
+		my $bf = $b;
+
+		my $bfe = [*] ($bf xx $exp);
+		while $current / $x > $tol && @digits.elems < $length {
+			my $digit = floor($current / $bfe);
+			@digits .= push($digit);
+			$current -= $digit * $bfe;
+			$exp--;
+			$bfe = $bfe / $bf;
+		}
 	}
 
 	return @digits, $n + 1;
@@ -331,13 +358,21 @@ multi sub real-digits(Numeric:D $x is copy,
 #==========================================================
 # Phi number system
 #==========================================================
-# Using N[Sqrt[5].100] in Wolfram Language
-our constant $sqrt5 = 2.236067977499789696409173668731276235440618359611525724270897245410520925637804899414414408378782275.FatRat;
+# Using N[Sqrt[5], 100] in Wolfram Language
+constant $sqrt5 = 2.236067977499789696409173668731276235440618359611525724270897245410520925637804899414414408378782275.FatRat;
 
-our constant \ϕ is export = (1.FatRat + $sqrt5) / 2.FatRat ;
+# Fibonacci 401 and 400
+constant $fibonacci401 = 284812298108489611757988937681460995615380088782304890986477195645969271404032323901.FatRat;
+constant $fibonacci400 = 176023680645013966468226945392411250770384383304492191886725992896575345044216019675.FatRat;
 
+#| Golden ratio (phi)
+our constant \phi is export = $fibonacci401 / $fibonacci400;
+our constant \ϕ is export = $fibonacci401 / $fibonacci400;
+#our constant \ϕ is export = (1.FatRat + $sqrt5) / 2.FatRat;
+
+#|
 sub phi-number-system(Int:D $n, Numeric:D :$tol = 10e-16, :$length is copy = Whatever) is export {
 	if $length.isa(Whatever) { $length = 2 * ($sqrt5 * abs($n)).log(ϕ).floor + 1; }
-	my ($digits, $exp) = real-digits($n, ϕ, :$tol, :$length);
+	my ($digits, $exp) = real-digits($n.FatRat, ϕ, :$tol, :$length);
 	return $exp <<->> ($digits.grep(* == 1, :k) >>+>> 1);
 }

--- a/lib/Math/Sequences/Numberphile.rakumod
+++ b/lib/Math/Sequences/Numberphile.rakumod
@@ -331,8 +331,11 @@ multi sub real-digits(Numeric:D $x is copy,
 		my $bfe = [*] ($bf xx $exp);
 		while $current / $x > $tol && @digits.elems < $length {
 			#note (:$exp, power => $bf ** $exp, :$bfe);
-			my $digit = floor($current / $bfe);
+			#note '$current / $bfe => ', $current / $bfe;
+			my $r = $current / $bfe;
+			my $digit = do if $r.round(10 ** -100) == 1 { 1 } else { ($current / $bfe).floor };
 			@digits .= push($digit);
+			#note (:$digit, '$digit.FatRat * $bfe => ', $digit.FatRat * $bfe);
 			$current -= $digit.FatRat * $bfe;
 			#note (:$current);
 			$exp--;

--- a/lib/Math/Sequences/Numberphile.rakumod
+++ b/lib/Math/Sequences/Numberphile.rakumod
@@ -301,7 +301,7 @@ our @A316667 is export = spiral-knight;
 # Real digits
 #==========================================================
 #| Real digits
-proto sub real-digits(Numeric:D $x, Numeric:D $b, *%args) is export {*}
+proto sub real-digits(Numeric:D $x, Numeric:D $b = 10, $n = Whatever, *%args) is export {*}
 
 multi sub real-digits(Int:D $x, *@args, *%args) {
 	return real-digits($x.FatRat, |@args, |%args);
@@ -311,7 +311,7 @@ multi sub real-digits(Numeric:D $x is copy,
 					  Numeric:D $b = 10,
 					  $n is copy = Whatever,
 					  Numeric:D :$tol = 10e-14,
-					  :len(:$length) is copy = Inf) {
+					  :l(:len(:$length)) is copy = Inf) {
 	if $x == 0 { return 0, 0}
 	$x = abs($x);
 	my @digits;
@@ -319,7 +319,7 @@ multi sub real-digits(Numeric:D $x is copy,
 
 	if $length.isa(Whatever) { $length = Inf }
 	die 'The argument $length is expected to be a positive integer or Whatever.'
-	unless $length ~~ Int:D && $length > 0;
+	unless ($length === Inf || $length ~~ Int:D) && $length > 0;
 
 	if $n.isa(Whatever) { $n = $x.log($b).floor}
 	die 'The third argument is expected to be a number or Whatever.' unless $n ~~ Numeric:D;

--- a/lib/Math/Sequences/Numberphile.rakumod
+++ b/lib/Math/Sequences/Numberphile.rakumod
@@ -301,24 +301,24 @@ our @A316667 is export = spiral-knight;
 # Real digits
 #==========================================================
 #| Real digits
-proto sub real-digits($x, $b, *%args) is export {*}
+proto sub real-digits(Numeric:D $x, Numeric:D $b, *%args) is export {*}
 
-multi sub real-digits($x,
-					  $b = 10,
+multi sub real-digits(Numeric:D $x is copy,
+					  Numeric:D $b = 10,
 					  $n is copy = Whatever,
 					  Numeric:D :$tol = 10e-14,
 					  :len(:$length) is copy = Inf) {
-	my $abs-x = abs($x);
+	if $x == 0 { return 0, 0}
+	$x = abs($x);
 	my @digits;
-	my $current = $abs-x;
+	my $current = $x;
 
 	if $length.isa(Whatever) { $length = Inf }
 
 	if $n.isa(Whatever) { $n = $x.log($b).floor}
-	if $n.isa(Whatever) { $n = $x.log($b).floor}
 	my $exp = $n;
 
-	while $current > $tol && @digits.elems < $length {
+	while $current / $x > $tol && @digits.elems < $length {
 		my $digit = floor($current / ($b ** $exp));
 		@digits .= push($digit);
 		$current -= $digit * ($b ** $exp);
@@ -336,8 +336,8 @@ our constant $sqrt5 = 2.23606797749978969640917366873127623544061835961152572427
 
 our constant \ϕ is export = (1.FatRat + $sqrt5) / 2.FatRat ;
 
-sub phi-number-system(Int:D $n, :$tol = 10e-16, :$length is copy = Whatever) is export {
-	if $length.isa(Whatever) { $length = 2 * (sqrt(5) * abs($n)).log(ϕ).floor + 3; }
+sub phi-number-system(Int:D $n, Numeric:D :$tol = 10e-16, :$length is copy = Whatever) is export {
+	if $length.isa(Whatever) { $length = 2 * ($sqrt5 * abs($n)).log(ϕ).floor + 1; }
 	my ($digits, $exp) = real-digits($n, ϕ, :$tol, :$length);
-	$exp <<->> ($digits.grep(* == 1, :k) >>+>> 1)
+	return $exp <<->> ($digits.grep(* == 1, :k) >>+>> 1);
 }

--- a/t/real-digits.rakutest
+++ b/t/real-digits.rakutest
@@ -12,6 +12,21 @@ isa-ok real-digits(12), List;
 is-deeply real-digits(12, e, length => 3), ([1, 1, 1], 3);
 
 ## 4
-isa-ok phi-number-system(32), List;
+subtest {
+    isa-ok phi-number-system(32), List;
+
+    # Expected ϕ-digits for 32
+    is phi-number-system(32), [7, 2, -3, -5, -9];
+
+    # Getting many ϕ-digits
+    my @res = phi-number-system(32, :40length);
+
+    # Expected representation
+    is @res.map({ ϕ ** $_ }).sum.round(10e-7), 32;
+
+    # There is Raku-bignum lost of precision real-digits, hence, the
+    # Phi number system representation of integers cannot be demonstrated.
+    # See https://mathworld.wolfram.com/PhiNumberSystem.html
+}
 
 done-testing

--- a/t/real-digits.rakutest
+++ b/t/real-digits.rakutest
@@ -1,0 +1,17 @@
+use Test;
+
+use Math::Sequences::Numberphile;
+
+## 1
+isa-ok real-digits(123.456), List;
+
+## 2
+isa-ok real-digits(12), List;
+
+## 3
+is-deeply real-digits(12, e, length => 3), ([1, 1, 1], 3);
+
+## 4
+isa-ok phi-number-system(32), List;
+
+done-testing

--- a/t/real-digits.rakutest
+++ b/t/real-digits.rakutest
@@ -16,7 +16,7 @@ subtest {
     isa-ok phi-number-system(32), List;
 
     # Expected ϕ-digits for 32
-    is phi-number-system(32), [7, 2, -3, -5, -9];
+    is phi-number-system(32), [7, 2, -3, -5, -8];
 
     # Getting many ϕ-digits
     my @res = phi-number-system(32, :40length);


### PR DESCRIPTION
This PR contains:

- Golden ratio constant with precision 100
  -  Both symbols `\ϕ` and `\phi` are provided.
- Sub `real-digits` that finds the digits of a number into a given real-base number system
- Sub `phi-number-system` that converts an integer into [Phi number system](https://mathworld.wolfram.com/PhiNumberSystem.html)